### PR TITLE
add box and note indicating incomplete data

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -92,7 +92,7 @@ async function showViz(
               baseline: "bottom",
               dy: -76,
               text:
-                "Due to reporting lags, data for most recent weeks is incomplete",
+                "Due to reporting lags, data for most recent weeks (in gray) is incomplete",
             },
             encoding: {
               x: { field: "lagDateEnd", type: "temporal" },


### PR DESCRIPTION
To address #3, I've added a simple grey box at the end of the graph and a note to indicate the incomplete data. I tried to make it easy to change the number of weeks if we want to revaluate as more data comes in if the lag gets better/worse. 

The diff looks a bit messed up because the nesting structured changed when I had to add another "layer" section, but all I did was add this little section to the vega-lite json:
<details>
<summary>vega-lite snippet</summary>

```
     {
        data: {
          values: [
            {
              lagDateStart: EvictionDataLagStart,
              lagDateEnd: EvictionDataLagEnd,
            },
          ],
        },
        layer: [
          {
            mark: { type: "rect", color: "grey", opacity: 0.3 },
            encoding: {
              x: { field: "lagDateStart", type: "temporal" },
              x2: { field: "lagDateEnd", type: "temporal" },
            },
          },
          {
            mark: {
              type: "text",
              align: "right",
              baseline: "bottom",
              dy: -76,
              text:
                "Due to reporting lags, data for most recent weeks is incomplete",
            },
            encoding: {
              x: { field: "lagDateEnd", type: "temporal" },
            },
          },
        ],
      },
```
</details>


![image](https://user-images.githubusercontent.com/16906516/101705628-5d7c7200-3a55-11eb-9d53-3cc70449dea9.png)