### PR TITLE
Add radios for grouping time series by week/month

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,10 @@
          */
         height: auto;
       }
+
+      input[type="radio"] {
+        margin-right: 5px;
+      }
     </style>
   </head>
   <body>

--- a/index.tsx
+++ b/index.tsx
@@ -41,14 +41,14 @@ Vega.expressionFunction("numberWithCommas", numberWithCommas);
  */
 function getEvictionDataLagDate(
   data: EvictionTimeSeriesRow[],
-  lagWeeks: number
+  lagDays: number
 ): string {
   const maxEvictionDateNum = Math.max.apply(
     Math,
-    data.map(row => Date.parse(row.week))
+    data.map(row => Date.parse(row.day))
   );
   let returnDate = new Date(maxEvictionDateNum);
-  returnDate.setDate(returnDate.getDate() - lagWeeks * 7);
+  returnDate.setDate(returnDate.getDate() - lagDays);
   returnDate.setHours(0, 0, 0, 0);
   return returnDate.toISOString();
 }
@@ -77,11 +77,11 @@ const EvictionViz: React.FC<{
   title: string,
 }> = ({values, fieldName, title}) => {
   const casesSinceCovid = values.filter(
-    row => row.week >= "2020-03-23 00:00:00"
+    row => row.day >= "2020-03-23 00:00:00"
   ).reduce(
     (total, row) => total + row[fieldName], 0
   );
-  const EvictionDataLagStart = getEvictionDataLagDate(values, 4); // 4 weeks for lag
+  const EvictionDataLagStart = getEvictionDataLagDate(values, 30); // 4 weeks for lag
   const EvictionDataLagEnd = getEvictionDataLagDate(values, 0); // latest date
   const spec: VisualizationSpec = {
     $schema: "https://vega.github.io/schema/vega-lite/v4.json",
@@ -131,18 +131,20 @@ const EvictionViz: React.FC<{
         },
         encoding: {
           x: {
-            field: "week",
-            type: "temporal",
+            timeUnit: "yearweek",
+            field: "day",
           },
           tooltip: [
             {
-              field: "week",
+              field: "day",
+              timeUnit: "yearweek",
               title: "Week of",
               type: "temporal",
               format: "%b %d, %Y",
             },
             {
               field: fieldName,
+              aggregate: "sum",
               title: "Filings",
               formatType: "numberWithCommas"
             },
@@ -157,8 +159,8 @@ const EvictionViz: React.FC<{
             },
             encoding: {
               x: {
-                field: "week",
-                type: "temporal",
+                timeUnit: "yearweek",
+                field: "day",
                 axis: {
                   title: "",
                   format: "%b ’%y",
@@ -167,7 +169,7 @@ const EvictionViz: React.FC<{
               },
               y: {
                 field: fieldName,
-                type: "quantitative",
+                aggregate: "sum",
                 axis: {
                   title: "Eviction Filings per Week",
                 },
@@ -188,11 +190,12 @@ const EvictionViz: React.FC<{
             mark: { type: "point", strokeWidth: 4},
             encoding: {
               x: {
-                field: "week",
-                type: "temporal",
+                timeUnit: "yearweek",
+                field: "day",
               },
               y: {
                 field: fieldName,
+                aggregate: "sum",
                 type: "quantitative",
               },
               opacity: {

--- a/index.tsx
+++ b/index.tsx
@@ -76,6 +76,9 @@ const EvictionViz: React.FC<{
   fieldName: keyof EvictionTimeSeriesNumericFields,
   title: string,
 }> = ({values, fieldName, title}) => {
+  values = values.filter(
+    row => row.day >= "2020-01-01 00:00:00"
+  );
   const casesSinceCovid = values.filter(
     row => row.day >= "2020-03-23 00:00:00"
   ).reduce(

--- a/index.tsx
+++ b/index.tsx
@@ -100,7 +100,7 @@ const EvictionViz: React.FC<{
       bottom: 50
     },
     title: {
-      text: `${title}, 2019 - Present`,
+      text: `${title}, 2020 - Present`,
       subtitle: [
         `Cases since COVID-19: ${casesSinceCovid.toLocaleString()}`,
         // This effectively adds extra padding below the subtitle.

--- a/index.tsx
+++ b/index.tsx
@@ -90,6 +90,7 @@ const EvictionViz: React.FC<{
   const EvictionDataLagStart = getEvictionDataLagDate(values, 30); // 4 weeks for lag
   const EvictionDataLagEnd = getEvictionDataLagDate(values, 0); // latest date
   const timeUnitLabel = timeUnit === "yearweek" ? "Week" : "Month";
+  const lineColor = "#AF2525";
   const spec: VisualizationSpec = {
     $schema: "https://vega.github.io/schema/vega-lite/v4.json",
     description: title,
@@ -168,7 +169,7 @@ const EvictionViz: React.FC<{
           {
             mark: {
               type: "line",
-              color: "#AF2525",
+              color: lineColor,
               interpolate: "monotone",
             },
             encoding: {
@@ -201,7 +202,7 @@ const EvictionViz: React.FC<{
                 clear: "mouseout"
               },
             },
-            mark: { type: "point", strokeWidth: 4},
+            mark: { type: "point", strokeWidth: 4, color: lineColor },
             encoding: {
               x: {
                 timeUnit,

--- a/index.tsx
+++ b/index.tsx
@@ -86,6 +86,8 @@ const EvictionViz: React.FC<{
   );
   const EvictionDataLagStart = getEvictionDataLagDate(values, 30); // 4 weeks for lag
   const EvictionDataLagEnd = getEvictionDataLagDate(values, 0); // latest date
+  const timeUnit = "yearweek";
+  const timeUnitLabel = "Week";
   const spec: VisualizationSpec = {
     $schema: "https://vega.github.io/schema/vega-lite/v4.json",
     description: title,
@@ -134,14 +136,14 @@ const EvictionViz: React.FC<{
         },
         encoding: {
           x: {
-            timeUnit: "yearweek",
+            timeUnit,
             field: "day",
           },
           tooltip: [
             {
               field: "day",
-              timeUnit: "yearweek",
-              title: "Week of",
+              timeUnit,
+              title: `${timeUnitLabel} of`,
               type: "temporal",
               format: "%b %d, %Y",
             },
@@ -162,7 +164,7 @@ const EvictionViz: React.FC<{
             },
             encoding: {
               x: {
-                timeUnit: "yearweek",
+                timeUnit,
                 field: "day",
                 axis: {
                   title: "",
@@ -174,7 +176,7 @@ const EvictionViz: React.FC<{
                 field: fieldName,
                 aggregate: "sum",
                 axis: {
-                  title: "Eviction Filings per Week",
+                  title: `Eviction Filings per ${timeUnitLabel}`,
                 },
               },
             },
@@ -193,7 +195,7 @@ const EvictionViz: React.FC<{
             mark: { type: "point", strokeWidth: 4},
             encoding: {
               x: {
-                timeUnit: "yearweek",
+                timeUnit,
                 field: "day",
               },
               y: {

--- a/index.tsx
+++ b/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import ReactDOM from "react-dom";
 
 import { getHTMLElement } from "@justfixnyc/util";
@@ -71,11 +71,14 @@ const VegaLite: React.FC<{spec: VisualizationSpec}> = ({spec}) => {
   return <div ref={ref}></div>;
 };
 
+type EvictionTimeUnit = "yearweek"|"yearmonth";
+
 const EvictionViz: React.FC<{
   values: EvictionTimeSeriesRow[],
   fieldName: keyof EvictionTimeSeriesNumericFields,
   title: string,
-}> = ({values, fieldName, title}) => {
+  timeUnit: EvictionTimeUnit
+}> = ({values, fieldName, title, timeUnit}) => {
   values = values.filter(
     row => row.day >= "2020-01-01 00:00:00"
   );
@@ -86,8 +89,7 @@ const EvictionViz: React.FC<{
   );
   const EvictionDataLagStart = getEvictionDataLagDate(values, 30); // 4 weeks for lag
   const EvictionDataLagEnd = getEvictionDataLagDate(values, 0); // latest date
-  const timeUnit = "yearweek";
-  const timeUnitLabel = "Week";
+  const timeUnitLabel = timeUnit === "yearweek" ? "Week" : "Month";
   const spec: VisualizationSpec = {
     $schema: "https://vega.github.io/schema/vega-lite/v4.json",
     description: title,
@@ -285,15 +287,30 @@ const ZipCodeViz: React.FC<{values: FilingsByZipRow[]}> = ({values}) => {
   }} />;
 };
 
-const EvictionVisualizations: React.FC<{values: EvictionTimeSeriesRow[]}> = ({values}) => (
-  <>
-    <EvictionViz values={values} fieldName="total_filings" title="Total NY State Eviction Filings" />
-    <EvictionViz values={values} fieldName="nyc_holdover_filings" title="NYC Holdover Filings" />
-    <EvictionViz values={values} fieldName="nyc_nonpay_filings" title="NYC Non-Payment Filings" />
-    <EvictionViz values={values} fieldName="outside_nyc_holdover_filings" title="Upstate Holdover Filings" />
-    <EvictionViz values={values} fieldName="outside_nyc_nonpay_filings" title="Upstate Non-Payment Filings" />
-  </>
-);
+const EvictionVisualizations: React.FC<{values: EvictionTimeSeriesRow[]}> = ({values}) => {
+  const [timeUnit, setTimeUnit] = useState<EvictionTimeUnit>("yearweek");
+
+  return (
+    <>
+      <p>
+        View by:&nbsp;&nbsp;
+        <label>
+          <input type="radio" name="timeUnit" value="yearweek" checked={timeUnit === "yearweek"} onClick={(e) => setTimeUnit("yearweek")} />
+          Week
+        </label>&nbsp;&nbsp;
+        <label>
+          <input type="radio" name="timeUnit" value="yearmonth" checked={timeUnit === "yearmonth"} onClick={(e) => setTimeUnit("yearmonth")} />
+          Month
+        </label>
+      </p>
+      <EvictionViz timeUnit={timeUnit} values={values} fieldName="total_filings" title="Total NY State Eviction Filings" />
+      <EvictionViz timeUnit={timeUnit} values={values} fieldName="nyc_holdover_filings" title="NYC Holdover Filings" />
+      <EvictionViz timeUnit={timeUnit} values={values} fieldName="nyc_nonpay_filings" title="NYC Non-Payment Filings" />
+      <EvictionViz timeUnit={timeUnit} values={values} fieldName="outside_nyc_holdover_filings" title="Upstate Holdover Filings" />
+      <EvictionViz timeUnit={timeUnit} values={values} fieldName="outside_nyc_nonpay_filings" title="Upstate Non-Payment Filings" />
+    </>
+  );
+};
 
 const DatasetDownloads: React.FC<{files: QueryFiles, title: string}> = ({files, title}) => (
   <>

--- a/index.tsx
+++ b/index.tsx
@@ -95,9 +95,16 @@ const EvictionViz: React.FC<{
     description: title,
     width: 750,
     height: 150,
+    padding: {
+      bottom: 50
+    },
     title: {
       text: `${title}, 2019 - Present`,
-      subtitle: `Cases since COVID-19: ${casesSinceCovid.toLocaleString()}`
+      subtitle: [
+        `Cases since COVID-19: ${casesSinceCovid.toLocaleString()}`,
+        // This effectively adds extra padding below the subtitle.
+        ""
+      ]
     },
     layer: [
       {

--- a/index.tsx
+++ b/index.tsx
@@ -328,6 +328,7 @@ async function main() {
       <h2>Filings by zip code</h2>
       <ZipCodeViz values={zipcodeValues} />
       <DatasetDownloads files={FILINGS_BY_ZIP} title="filings by zip code" />
+      <br/>
       <h2>Filings over time</h2>
       <EvictionVisualizations values={evictionValues} />
       <DatasetDownloads files={EVICTION_TIME_SERIES} title="filings over time" />

--- a/lib/eviction-time-series.ts
+++ b/lib/eviction-time-series.ts
@@ -5,7 +5,7 @@ export const EVICTION_TIME_SERIES = new QueryFiles(`eviction-time-series`);
 
 export function convertEvictionTimeSeriesRow(row: any) {
   return {
-    week: (row.week as Date).toISOString(),
+    day: (row.day as Date).toISOString(),
     nyc_holdover_filings: toInt(row.nyc_holdover_filings),
     nyc_nonpay_filings: toInt(row.nyc_nonpay_filings),
     outside_nyc_holdover_filings: toInt(row.outside_nyc_holdover_filings),
@@ -16,11 +16,11 @@ export function convertEvictionTimeSeriesRow(row: any) {
 
 export type EvictionTimeSeriesRow = ReturnType<typeof convertEvictionTimeSeriesRow>;
 
-export type EvictionTimeSeriesNumericFields = Omit<EvictionTimeSeriesRow, "week">;
+export type EvictionTimeSeriesNumericFields = Omit<EvictionTimeSeriesRow, "day">;
 
 function getEvictionTimeSeriesCsvHeader(): string[] {
   return [
-    'week',
+    'day',
     'nyc_holdover_filings',
     'nyc_nonpay_filings',
     'outside_nyc_holdover_filings',
@@ -31,7 +31,7 @@ function getEvictionTimeSeriesCsvHeader(): string[] {
 
 function toEvictionTimeSeriesCsvRow(row: EvictionTimeSeriesRow): string[] {
   return [
-    row.week.substr(0, 10),
+    row.day.substr(0, 10),
     row.nyc_holdover_filings.toString(),
     row.nyc_nonpay_filings.toString(),
     row.outside_nyc_holdover_filings.toString(),

--- a/sql/eviction-time-series.sql
+++ b/sql/eviction-time-series.sql
@@ -1,19 +1,19 @@
-with weeks as (
+with days as (
 	select *
-    from generate_series('01-07-2019', CURRENT_DATE - '1 WEEK'::INTERVAL, '1 WEEK'::INTERVAL) week
+    from generate_series('01-01-2019', CURRENT_DATE - '1 WEEK'::INTERVAL, '1 DAY'::INTERVAL) day
 )
 select 
-	week, 
+	day, 
 	count(*) filter (where classification = 'Holdover' and region = 'NYC') as nyc_holdover_filings,
 	count(*) filter (where classification = 'Non-Payment' and region = 'NYC') as nyc_nonpay_filings,
 	count(*) filter (where classification = 'Holdover' and region = 'Outside NYC') as outside_nyc_holdover_filings,
 	count(*) filter (where classification = 'Non-Payment' and region = 'Outside NYC') as outside_nyc_nonpay_filings,
 	count(*) filter (where indexnumberid is not null) as total_filings
-	from weeks
+	from days
 	left join (
 		select 
 			i.*,
-			date_trunc('week', i.fileddate)::date as week,
+			date_trunc('day', i.fileddate)::date as day,
 			case when 
 				(court = any('{
 					Bronx County Civil Court,
@@ -28,6 +28,6 @@ select
 		from oca_index i 
 		where i.fileddate >= '01-01-2019' and i.classification = any('{Holdover,Non-Payment}') 
 		order by i.fileddate asc 
-	) eviction_cases using(week)
-group by week
-order by week;
+	) eviction_cases using(day)
+group by day
+order by day;


### PR DESCRIPTION
This adds radios that make it easy to switch the visualization between grouping by week or month.

> ![image](https://user-images.githubusercontent.com/124687/102416510-f700d200-3fc7-11eb-8830-d9848bd736c3.png)

It also changes the CSV/JSON of the time series to include a "day" column instead of a "week" column; the actual grouping is done in vega lite on the page.

It also makes a few other stylistic changes, such as increasing padding/spacing.

We also only show the time series data from the beginning of 2020 in the visualization now, fixing #10.  The CSV/JSON files still include data prior to 2020, though.