### PR TITLE
Lazy-load data and code.

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,12 @@
         width: 100%;
         height: 300px;
       }
+
+      .loading {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
     </style>
   </head>
   <body>

--- a/index.tsx
+++ b/index.tsx
@@ -2,16 +2,11 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 import { getHTMLElement } from "@justfixnyc/util";
-import { EvictionTimeSeriesRow, EVICTION_TIME_SERIES } from "./lib/eviction-time-series/data";
-
+import { EVICTION_TIME_SERIES } from "./lib/eviction-time-series/data";
 import { FILINGS_BY_ZIP } from "./lib/filings-by-zip/data";
 import { QueryFiles } from "./lib/query";
 import { EvictionVisualizations } from "./lib/eviction-time-series/viz";
 import { ZipCodeViz } from "./lib/filings-by-zip/viz";
-
-async function fetchJSON<T>(path: string): Promise<T> {
-  return (await fetch(path)).json();
-}
 
 const DatasetDownloads: React.FC<{files: QueryFiles, title: string}> = ({files, title}) => (
   <>
@@ -21,8 +16,6 @@ const DatasetDownloads: React.FC<{files: QueryFiles, title: string}> = ({files, 
 );
 
 async function main() {
-  const evictionValues = await fetchJSON<EvictionTimeSeriesRow[]>(EVICTION_TIME_SERIES.json);
-
   ReactDOM.render(
     <div>
       <h2>Filings by zip code</h2>
@@ -30,7 +23,7 @@ async function main() {
       <DatasetDownloads files={FILINGS_BY_ZIP} title="filings by zip code" />
       <br/>
       <h2>Filings over time</h2>
-      <EvictionVisualizations values={evictionValues} height={150} />
+      <EvictionVisualizations height={150} />
       <DatasetDownloads files={EVICTION_TIME_SERIES} title="filings over time" />
     </div>,
     getHTMLElement('div', '#app')

--- a/index.tsx
+++ b/index.tsx
@@ -4,7 +4,7 @@ import ReactDOM from "react-dom";
 import { getHTMLElement } from "@justfixnyc/util";
 import { EvictionTimeSeriesRow, EVICTION_TIME_SERIES } from "./lib/eviction-time-series/data";
 
-import { FilingsByZipRow, FILINGS_BY_ZIP } from "./lib/filings-by-zip/data";
+import { FILINGS_BY_ZIP } from "./lib/filings-by-zip/data";
 import { QueryFiles } from "./lib/query";
 import { EvictionVisualizations } from "./lib/eviction-time-series/viz";
 import { ZipCodeViz } from "./lib/filings-by-zip/viz";
@@ -22,12 +22,11 @@ const DatasetDownloads: React.FC<{files: QueryFiles, title: string}> = ({files, 
 
 async function main() {
   const evictionValues = await fetchJSON<EvictionTimeSeriesRow[]>(EVICTION_TIME_SERIES.json);
-  const zipcodeValues = await fetchJSON<FilingsByZipRow[]>(FILINGS_BY_ZIP.json);
 
   ReactDOM.render(
     <div>
       <h2>Filings by zip code</h2>
-      <ZipCodeViz values={zipcodeValues} height={600} />
+      <ZipCodeViz height={600} />
       <DatasetDownloads files={FILINGS_BY_ZIP} title="filings by zip code" />
       <br/>
       <h2>Filings over time</h2>

--- a/index.tsx
+++ b/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Suspense } from "react";
 import ReactDOM from "react-dom";
 
 import { getHTMLElement } from "@justfixnyc/util";
@@ -6,7 +6,9 @@ import { EVICTION_TIME_SERIES } from "./lib/eviction-time-series/data";
 import { FILINGS_BY_ZIP } from "./lib/filings-by-zip/data";
 import { QueryFiles } from "./lib/query";
 import { EvictionVisualizations } from "./lib/eviction-time-series/viz";
-import { ZipCodeViz } from "./lib/filings-by-zip/viz";
+import { VizFallback, VIZ_GEO_CLASS } from "./lib/viz-util";
+
+const ZipCodeViz = React.lazy(() => import("./lib/filings-by-zip/viz"));
 
 const DatasetDownloads: React.FC<{files: QueryFiles, title: string}> = ({files, title}) => (
   <>
@@ -19,7 +21,9 @@ async function main() {
   ReactDOM.render(
     <div>
       <h2>Filings by zip code</h2>
-      <ZipCodeViz height={600} />
+      <Suspense fallback={<VizFallback className={VIZ_GEO_CLASS} />}>
+        <ZipCodeViz height={600} />
+      </Suspense>
       <DatasetDownloads files={FILINGS_BY_ZIP} title="filings by zip code" />
       <br/>
       <h2>Filings over time</h2>

--- a/lib/eviction-time-series/viz.tsx
+++ b/lib/eviction-time-series/viz.tsx
@@ -3,9 +3,8 @@ import { useState } from "react";
 import { VisualizationSpec } from "vega-embed";
 import { JsonLoader } from "../json-loader";
 import { VegaLite } from "../vega";
+import { VizFallback, VIZ_TIME_SERIES_CLASS } from "../viz-util";
 import { EvictionTimeSeriesNumericFields, EvictionTimeSeriesRow, EVICTION_TIME_SERIES } from "./data";
-
-const VIZ_TIME_SERIES_CLASS = "viz-time-series";
 
 /**
  * Take the array of data rows and get the date for the latest week we
@@ -39,7 +38,7 @@ type EvictionVizProps = {
 
 const EvictionViz: React.FC<EvictionVizProps> = (props) => {
   return (
-    <JsonLoader<EvictionTimeSeriesRow[]> url={EVICTION_TIME_SERIES.json} fallback={<div className={VIZ_TIME_SERIES_CLASS} />}>
+    <JsonLoader<EvictionTimeSeriesRow[]> url={EVICTION_TIME_SERIES.json} fallback={<VizFallback className={VIZ_TIME_SERIES_CLASS} />}>
       {(values) => <EvictionVizWithValues values={values} {...props} />}
     </JsonLoader>
   );

--- a/lib/eviction-time-series/viz.tsx
+++ b/lib/eviction-time-series/viz.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { useState } from "react";
-import { VisualizationSpec } from "vega-embed";
+import type { VisualizationSpec } from "vega-embed";
 import { JsonLoader } from "../json-loader";
-import { VegaLite } from "../vega";
+import { LazyVegaLite } from "../vega-lazy";
 import { VizFallback, VIZ_TIME_SERIES_CLASS } from "../viz-util";
 import { EvictionTimeSeriesNumericFields, EvictionTimeSeriesRow, EVICTION_TIME_SERIES } from "./data";
 
@@ -196,7 +196,7 @@ const EvictionVizWithValues: React.FC<EvictionVizProps & {
     ],
   };
 
-  return <VegaLite spec={spec} className={VIZ_TIME_SERIES_CLASS} />;
+  return <LazyVegaLite spec={spec} className={VIZ_TIME_SERIES_CLASS} />;
 };
 
 export const EvictionVisualizations: React.FC<{

--- a/lib/filings-by-zip/viz.tsx
+++ b/lib/filings-by-zip/viz.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { JsonLoader } from "../json-loader";
-import { VegaLite } from "../vega";
+import { LazyVegaLite } from "../vega-lazy";
 import { VizFallback, VIZ_GEO_CLASS } from "../viz-util";
 import { FilingsByZipRow, FILINGS_BY_ZIP, FILINGS_BY_ZIP_EMPTY_ROW } from "./data";
 
@@ -44,7 +44,7 @@ const ZipCodeVizWithValues: React.FC<{
 }> = ({values, height}) => {
   const geoJson = mergeZipcodeFilingsIntoGeoJSON(values);
 
-  return <VegaLite className={VIZ_GEO_CLASS} spec={{
+  return <LazyVegaLite className={VIZ_GEO_CLASS} spec={{
     $schema: "https://vega.github.io/schema/vega-lite/v4.json",
     width: "container",
     height,

--- a/lib/filings-by-zip/viz.tsx
+++ b/lib/filings-by-zip/viz.tsx
@@ -1,9 +1,12 @@
 import React from "react";
+import { JsonLoader } from "../json-loader";
 import { VegaLite } from "../vega";
-import { FilingsByZipRow, FILINGS_BY_ZIP_EMPTY_ROW } from "./data";
+import { FilingsByZipRow, FILINGS_BY_ZIP, FILINGS_BY_ZIP_EMPTY_ROW } from "./data";
 
 // https://data.beta.nyc/dataset/nyc-zip-code-tabulation-areas
 import ZipCodeGeoJSON from "./nyc-zip-code-tabulation-areas.json";
+
+const VIZ_GEO_CLASS = "viz-geo";
 
 function mergeZipcodeFilingsIntoGeoJSON(values: FilingsByZipRow[]) {
   const map = new Map<string, FilingsByZipRow>();
@@ -25,12 +28,22 @@ function mergeZipcodeFilingsIntoGeoJSON(values: FilingsByZipRow[]) {
 }
 
 export const ZipCodeViz: React.FC<{
+  height: number,
+}> = (props) => {
+  return (
+    <JsonLoader<FilingsByZipRow[]> url={FILINGS_BY_ZIP.json} fallback={<div className={VIZ_GEO_CLASS} />}>
+      {(values) => <ZipCodeVizWithValues values={values} {...props} />}
+    </JsonLoader>
+  );
+};
+
+const ZipCodeVizWithValues: React.FC<{
   values: FilingsByZipRow[],
   height: number,
 }> = ({values, height}) => {
   const geoJson = mergeZipcodeFilingsIntoGeoJSON(values);
 
-  return <VegaLite className="viz-geo" spec={{
+  return <VegaLite className={VIZ_GEO_CLASS} spec={{
     $schema: "https://vega.github.io/schema/vega-lite/v4.json",
     width: "container",
     height,

--- a/lib/filings-by-zip/viz.tsx
+++ b/lib/filings-by-zip/viz.tsx
@@ -1,12 +1,11 @@
 import React from "react";
 import { JsonLoader } from "../json-loader";
 import { VegaLite } from "../vega";
+import { VizFallback, VIZ_GEO_CLASS } from "../viz-util";
 import { FilingsByZipRow, FILINGS_BY_ZIP, FILINGS_BY_ZIP_EMPTY_ROW } from "./data";
 
 // https://data.beta.nyc/dataset/nyc-zip-code-tabulation-areas
 import ZipCodeGeoJSON from "./nyc-zip-code-tabulation-areas.json";
-
-const VIZ_GEO_CLASS = "viz-geo";
 
 function mergeZipcodeFilingsIntoGeoJSON(values: FilingsByZipRow[]) {
   const map = new Map<string, FilingsByZipRow>();
@@ -27,15 +26,17 @@ function mergeZipcodeFilingsIntoGeoJSON(values: FilingsByZipRow[]) {
   };
 }
 
-export const ZipCodeViz: React.FC<{
+const ZipCodeViz: React.FC<{
   height: number,
 }> = (props) => {
   return (
-    <JsonLoader<FilingsByZipRow[]> url={FILINGS_BY_ZIP.json} fallback={<div className={VIZ_GEO_CLASS} />}>
+    <JsonLoader<FilingsByZipRow[]> url={FILINGS_BY_ZIP.json} fallback={<VizFallback className={VIZ_GEO_CLASS} />}>
       {(values) => <ZipCodeVizWithValues values={values} {...props} />}
     </JsonLoader>
   );
 };
+
+export default ZipCodeViz;
 
 const ZipCodeVizWithValues: React.FC<{
   values: FilingsByZipRow[],

--- a/lib/json-loader.tsx
+++ b/lib/json-loader.tsx
@@ -1,5 +1,21 @@
 import { useEffect, useState } from "react";
 
+const requests = new Map<string, Promise<any>>();
+
+function getRequest(url: string): Promise<any> {
+  let request = requests.get(url);
+  if (!request) {
+    request = fetch(url).then(res => {
+      if (!res.ok) {
+        throw new Error(`Got HTTP ${res.status} when fetching ${url}`);
+      }
+      return res.json();
+    });
+    requests.set(url, request);
+  }
+  return request;
+}
+
 export function JsonLoader<T>(props: {
   url: string,
   fallback: JSX.Element,
@@ -9,12 +25,8 @@ export function JsonLoader<T>(props: {
   const [data, setData] = useState<T|null>(null);
 
   useEffect(() => {
-    fetch(url).then(res => {
-      if (res.ok) {
-        res.json().then(resData => {
-          setData(resData);
-        });
-      }
+    getRequest(url).then(data => {
+      setData(data);
     });
   }, [url]);
 

--- a/lib/json-loader.tsx
+++ b/lib/json-loader.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+export function JsonLoader<T>(props: {
+  url: string,
+  fallback: JSX.Element,
+  children: (data: T) => JSX.Element,
+}): JSX.Element {
+  const { url } = props;
+  const [data, setData] = useState<T|null>(null);
+
+  useEffect(() => {
+    fetch(url).then(res => {
+      if (res.ok) {
+        res.json().then(resData => {
+          setData(resData);
+        });
+      }
+    });
+  }, [url]);
+
+  if (data === null) return props.fallback;
+
+  return props.children(data);
+}

--- a/lib/json-loader.tsx
+++ b/lib/json-loader.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useState } from "react";
 
+/** 
+ * Global singleton to cache all our data requests.
+ */
 const requests = new Map<string, Promise<any>>();
 
 function getRequest(url: string): Promise<any> {
@@ -16,6 +19,15 @@ function getRequest(url: string): Promise<any> {
   return request;
 }
 
+/**
+ * Lazily-load a JSON file, showing the given fallback component until
+ * the loading is complete.
+ * 
+ * Once the loading is complete, the child is rendered and passed
+ * the loaded data.
+ * 
+ * NOTE: At present, the data, once loaded, is never freed.
+ */
 export function JsonLoader<T>(props: {
   url: string,
   fallback: JSX.Element,

--- a/lib/vega-lazy.tsx
+++ b/lib/vega-lazy.tsx
@@ -1,0 +1,13 @@
+import React, { Suspense } from "react";
+import type { VegaLiteProps } from "./vega";
+import { VizFallback } from "./viz-util";
+
+const VegaLite = React.lazy(() => import("./vega"));
+
+export const LazyVegaLite: React.FC<VegaLiteProps> = props => {
+  return (
+    <Suspense fallback={<VizFallback className={props.className || ''} />}>
+      <VegaLite {...props} />
+    </Suspense>
+  );
+};

--- a/lib/vega-lazy.tsx
+++ b/lib/vega-lazy.tsx
@@ -4,6 +4,10 @@ import { VizFallback } from "./viz-util";
 
 const VegaLite = React.lazy(() => import("./vega"));
 
+/**
+ * Lazily-load a Vega visualization, showing a throbber while it's loading.
+ * This will also lazily load the Vega library itself, which can be quite large.
+ */
 export const LazyVegaLite: React.FC<VegaLiteProps> = props => {
   return (
     <Suspense fallback={<VizFallback className={props.className || ''} />}>

--- a/lib/vega.tsx
+++ b/lib/vega.tsx
@@ -19,10 +19,12 @@ function numberWithCommas(x: number): string {
 
 Vega.expressionFunction("numberWithCommas", numberWithCommas);
 
-export const VegaLite: React.FC<{
+export type VegaLiteProps = {
   spec: VisualizationSpec,
   className?: string,
-}> = ({spec, className}) => {
+};
+
+const VegaLite: React.FC<VegaLiteProps> = ({spec, className}) => {
   const ref: React.MutableRefObject<HTMLDivElement|null> = useRef(null);
 
   useEffect(() => {
@@ -39,3 +41,5 @@ export const VegaLite: React.FC<{
 
   return <div ref={ref} className={className}></div>;
 };
+
+export default VegaLite;

--- a/lib/viz-util.tsx
+++ b/lib/viz-util.tsx
@@ -21,5 +21,5 @@ const ChromiumThrobber: React.FC<{}> = () => (
 );
 
 export const VizFallback: React.FC<{className: string}> = ({className}) => (
-  <div className={className}><ChromiumThrobber /></div>
+  <div className={`${className} loading`}><ChromiumThrobber /></div>
 );

--- a/lib/viz-util.tsx
+++ b/lib/viz-util.tsx
@@ -4,6 +4,22 @@ export const VIZ_GEO_CLASS = "viz-geo";
 
 export const VIZ_TIME_SERIES_CLASS = "viz-time-series";
 
+// https://commons.wikimedia.org/wiki/File:Chromiumthrobber.svg
+const ChromiumThrobber: React.FC<{}> = () => (
+  <svg width="16" height="16" viewBox="0 0 300 300"
+        xmlns="http://www.w3.org/2000/svg" version="1.1">
+    <path d="M 150,0
+            a 150,150 0 0,1 106.066,256.066
+            l -35.355,-35.355
+            a -100,-100 0 0,0 -70.711,-170.711 z"
+          fill="#000000">
+      <animateTransform attributeName="transform" attributeType="XML"
+                        type="rotate" from="0 150 150" to="360 150 150"
+                        begin="0s" dur="1s" fill="freeze" repeatCount="indefinite" />
+    </path>
+  </svg>
+);
+
 export const VizFallback: React.FC<{className: string}> = ({className}) => (
-  <div className={className}></div>
+  <div className={className}><ChromiumThrobber /></div>
 );

--- a/lib/viz-util.tsx
+++ b/lib/viz-util.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 
+/** A visualization that represents a geographic map (e.g. chloropeth). */
 export const VIZ_GEO_CLASS = "viz-geo";
 
+/** A visualization that represents a time series. */
 export const VIZ_TIME_SERIES_CLASS = "viz-time-series";
 
 // https://commons.wikimedia.org/wiki/File:Chromiumthrobber.svg
@@ -20,6 +22,11 @@ const ChromiumThrobber: React.FC<{}> = () => (
   </svg>
 );
 
+/**
+ * Fallback component for a visualization that is still loading, letting
+ * the user know that loading is occurring without causing layout
+ * instability.
+ */
 export const VizFallback: React.FC<{className: string}> = ({className}) => (
   <div className={`${className} loading`}><ChromiumThrobber /></div>
 );

--- a/lib/viz-util.tsx
+++ b/lib/viz-util.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export const VIZ_GEO_CLASS = "viz-geo";
+
+export const VIZ_TIME_SERIES_CLASS = "viz-time-series";
+
+export const VizFallback: React.FC<{className: string}> = ({className}) => (
+  <div className={className}></div>
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,14 +5,14 @@
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es2019",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "module": "esnext",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     "jsx": "react",                           /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./tsc-dist",                        /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
@@ -42,7 +42,7 @@
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */


### PR DESCRIPTION
Currently we have one massively big bundle that needs to load all related JSON data before it can show anything.

This changes things to use `React.Lazy` and Parcel's code splitting to lazily load everything, without causing layout instability.

## To do

- [x] Show a throbber type thing while visualizations are loading.
