### PR TITLE
Add a widget and configurator

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,9 +56,7 @@
     </style>
   </head>
   <body>
-    <h1>New York Eviction Filings Tracker</h1>
     <div id="app">Loading&hellip;</div>
-    <p><a href="https://github.com/housing-data-coalition/rtc-eviction-viz">Learn more on GitHub</a></p>
     <script src="./index.tsx"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,7 +1,8 @@
 <html>
   <head>
-    <title>NY Eviction Filings Tracker</title>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>NY Eviction Filings Tracker</title>
     <style>
       html,
       body,

--- a/index.tsx
+++ b/index.tsx
@@ -20,6 +20,7 @@ const DatasetDownloads: React.FC<{files: QueryFiles, title: string}> = ({files, 
 async function main() {
   ReactDOM.render(
     <div className="viz-container">
+      <h1>New York Eviction Filings Tracker</h1>
       <h2>Filings by zip code</h2>
       <Suspense fallback={<VizFallback className={VIZ_GEO_CLASS} />}>
         <ZipCodeViz height={600} />
@@ -30,6 +31,7 @@ async function main() {
       <h2>Filings over time</h2>
       <EvictionVisualizations height={150} />
       <DatasetDownloads files={EVICTION_TIME_SERIES} title="filings over time" />
+      <p><a href="https://github.com/housing-data-coalition/rtc-eviction-viz">Learn more on GitHub</a></p>
     </div>,
     getHTMLElement('div', '#app')
   );

--- a/index.tsx
+++ b/index.tsx
@@ -2,11 +2,13 @@ import React, { Suspense } from "react";
 import ReactDOM from "react-dom";
 
 import { getHTMLElement } from "@justfixnyc/util";
-import { EVICTION_TIME_SERIES } from "./lib/eviction-time-series/data";
+import { EvictionTimeSeriesNumericFields, EVICTION_TIME_SERIES } from "./lib/eviction-time-series/data";
 import { FILINGS_BY_ZIP } from "./lib/filings-by-zip/data";
 import { QueryFiles } from "./lib/query";
-import { EvictionVisualizations } from "./lib/eviction-time-series/viz";
+import { EvictionVisualizations, isEvictionTimeSeriesNumericField } from "./lib/eviction-time-series/viz";
 import { VizFallback, VIZ_GEO_CLASS } from "./lib/viz-util";
+
+const EVICTION_VIZ_DEFAULT_HEIGHT = 150;
 
 const ZipCodeViz = React.lazy(() => import("./lib/filings-by-zip/viz"));
 
@@ -17,24 +19,41 @@ const DatasetDownloads: React.FC<{files: QueryFiles, title: string}> = ({files, 
   </>
 );
 
+const FullDocument: React.FC<{}> = () => (
+  <div className="viz-container">
+    <h1>New York Eviction Filings Tracker</h1>
+    <h2>Filings by zip code</h2>
+    <Suspense fallback={<VizFallback className={VIZ_GEO_CLASS} />}>
+      <ZipCodeViz height={600} />
+    </Suspense>
+    <small>Data sources: New York State Office of Court Administration eviction filings via github.com/nycdb/nycdb and PLUTO19v2. Total units per zip code excludes single-unit residential properties to approximate number of rental units.</small>
+    <DatasetDownloads files={FILINGS_BY_ZIP} title="filings by zip code" />
+    <br/>
+    <h2>Filings over time</h2>
+    <EvictionVisualizations height={EVICTION_VIZ_DEFAULT_HEIGHT} />
+    <DatasetDownloads files={EVICTION_TIME_SERIES} title="filings over time" />
+    <p><a href="https://github.com/housing-data-coalition/rtc-eviction-viz">Learn more on GitHub</a></p>
+  </div>
+);
+
+const Widget: React.FC<{fieldName: keyof EvictionTimeSeriesNumericFields}> = ({fieldName}) => {
+  return <EvictionVisualizations height={EVICTION_VIZ_DEFAULT_HEIGHT} fieldNames={[fieldName]} />;
+};
+
+function validateFieldName(fieldName: string): keyof EvictionTimeSeriesNumericFields {
+  return isEvictionTimeSeriesNumericField(fieldName) ? fieldName : "total_filings";
+}
+
 async function main() {
-  ReactDOM.render(
-    <div className="viz-container">
-      <h1>New York Eviction Filings Tracker</h1>
-      <h2>Filings by zip code</h2>
-      <Suspense fallback={<VizFallback className={VIZ_GEO_CLASS} />}>
-        <ZipCodeViz height={600} />
-      </Suspense>
-      <small>Data sources: New York State Office of Court Administration eviction filings via github.com/nycdb/nycdb and PLUTO19v2. Total units per zip code excludes single-unit residential properties to approximate number of rental units.</small>
-      <DatasetDownloads files={FILINGS_BY_ZIP} title="filings by zip code" />
-      <br/>
-      <h2>Filings over time</h2>
-      <EvictionVisualizations height={150} />
-      <DatasetDownloads files={EVICTION_TIME_SERIES} title="filings over time" />
-      <p><a href="https://github.com/housing-data-coalition/rtc-eviction-viz">Learn more on GitHub</a></p>
-    </div>,
-    getHTMLElement('div', '#app')
-  );
+  const search = new URLSearchParams(window.location.search);
+  let app = <FullDocument />;
+  const view = search.get('view');
+
+  if (view === "widget") {
+    app = <Widget fieldName={validateFieldName(search.get('fieldName') || '')} />;
+  }
+
+  ReactDOM.render(app, getHTMLElement('div', '#app'));
 }
 
 main();

--- a/index.tsx
+++ b/index.tsx
@@ -5,10 +5,18 @@ import { getHTMLElement } from "@justfixnyc/util";
 import { EvictionTimeSeriesNumericFields, EVICTION_TIME_SERIES } from "./lib/eviction-time-series/data";
 import { FILINGS_BY_ZIP } from "./lib/filings-by-zip/data";
 import { QueryFiles } from "./lib/query";
-import { EvictionVisualizations, isEvictionTimeSeriesNumericField } from "./lib/eviction-time-series/viz";
+import { EvictionVisualizations, EVICTION_VISUALIZATIONS, isEvictionTimeSeriesNumericField } from "./lib/eviction-time-series/viz";
 import { VizFallback, VIZ_GEO_CLASS } from "./lib/viz-util";
 
 const EVICTION_VIZ_DEFAULT_HEIGHT = 150;
+
+const VIEW_WIDGET = "widget";
+
+const VIEW_CONFIGURE_WIDGET = "config";
+
+const QS_VIEW = "view";
+
+const QS_FIELD_NAME = "fieldName";
 
 const ZipCodeViz = React.lazy(() => import("./lib/filings-by-zip/viz"));
 
@@ -32,6 +40,7 @@ const FullDocument: React.FC<{}> = () => (
     <h2>Filings over time</h2>
     <EvictionVisualizations height={EVICTION_VIZ_DEFAULT_HEIGHT} />
     <DatasetDownloads files={EVICTION_TIME_SERIES} title="filings over time" />
+    <p><a href={`?${QS_VIEW}=${VIEW_CONFIGURE_WIDGET}`}>Configure this page as a widget</a></p>
     <p><a href="https://github.com/housing-data-coalition/rtc-eviction-viz">Learn more on GitHub</a></p>
   </div>
 );
@@ -40,18 +49,45 @@ const Widget: React.FC<{fieldName: keyof EvictionTimeSeriesNumericFields}> = ({f
   return <EvictionVisualizations height={EVICTION_VIZ_DEFAULT_HEIGHT} fieldNames={[fieldName]} />;
 };
 
+const ConfigureWidget: React.FC<{}> = () => {
+  return (
+    <>
+      <h1>New York Eviction Filings Widget Configurator</h1>
+      <p>
+        Use the following form to generate a widget. Once you submit it, grab the URL
+        from the address bar and put it in an <code>&lt;iframe&gt;</code>. The widget will
+        horizontally expand to fill all available space, so make sure you style your
+        container as needed.
+      </p>
+      <form>
+        <input type="hidden" name={QS_VIEW} value={VIEW_WIDGET} />
+        <p>Time series visualization:</p>
+        {Array.from(EVICTION_VISUALIZATIONS.entries()).map(([fieldName, title]) => (
+          <div key={fieldName}>
+            <label>
+              <input type="radio" name={QS_FIELD_NAME} value={fieldName} />
+              {title}
+            </label>
+          </div>
+        ))}
+        <p><button type="submit">Show widget</button></p>
+      </form>
+      <p><a href="./">Go back</a></p>
+    </>
+  );
+};
+
 function validateFieldName(fieldName: string): keyof EvictionTimeSeriesNumericFields {
   return isEvictionTimeSeriesNumericField(fieldName) ? fieldName : "total_filings";
 }
 
 async function main() {
   const search = new URLSearchParams(window.location.search);
-  let app = <FullDocument />;
-  const view = search.get('view');
-
-  if (view === "widget") {
-    app = <Widget fieldName={validateFieldName(search.get('fieldName') || '')} />;
-  }
+  const view = search.get(QS_VIEW);
+  const app =
+    view === VIEW_WIDGET ? <Widget fieldName={validateFieldName(search.get(QS_FIELD_NAME) || '')} /> :
+    view === VIEW_CONFIGURE_WIDGET ? <ConfigureWidget /> :
+    <FullDocument />;
 
   ReactDOM.render(app, getHTMLElement('div', '#app'));
 }

--- a/lib/eviction-time-series/viz.tsx
+++ b/lib/eviction-time-series/viz.tsx
@@ -204,7 +204,7 @@ export function isEvictionTimeSeriesNumericField(value: string): value is keyof 
   return EVICTION_VISUALIZATIONS.has(value as any);
 }
 
-const EVICTION_VISUALIZATIONS: Map<keyof EvictionTimeSeriesNumericFields, string> = new Map([
+export const EVICTION_VISUALIZATIONS: Map<keyof EvictionTimeSeriesNumericFields, string> = new Map([
   ["total_filings", "Total NY State Eviction Filings"],
   ["nyc_holdover_filings", "NYC Holdover Filings"],
   ["nyc_nonpay_filings", "NYC Non-Payment Filings"],

--- a/lib/eviction-time-series/viz.tsx
+++ b/lib/eviction-time-series/viz.tsx
@@ -100,7 +100,7 @@ const EvictionVizWithValues: React.FC<EvictionVizProps & {
               type: "text",
               align: "right",
               baseline: "bottom",
-              dy: -76,
+              dy: -(height / 2) - 1,
               text:
                 "Due to reporting lags, data for most recent weeks (in gray) is incomplete",
             },

--- a/lib/eviction-time-series/viz.tsx
+++ b/lib/eviction-time-series/viz.tsx
@@ -200,6 +200,10 @@ const EvictionVizWithValues: React.FC<EvictionVizProps & {
   return <LazyVegaLite spec={spec} className={VIZ_TIME_SERIES_CLASS} />;
 };
 
+export function isEvictionTimeSeriesNumericField(value: string): value is keyof EvictionTimeSeriesNumericFields {
+  return EVICTION_VISUALIZATIONS.has(value as any);
+}
+
 const EVICTION_VISUALIZATIONS: Map<keyof EvictionTimeSeriesNumericFields, string> = new Map([
   ["total_filings", "Total NY State Eviction Filings"],
   ["nyc_holdover_filings", "NYC Holdover Filings"],

--- a/lib/eviction-time-series/viz.tsx
+++ b/lib/eviction-time-series/viz.tsx
@@ -1,3 +1,4 @@
+import { assertNotUndefined } from "@justfixnyc/util";
 import React from "react";
 import { useState } from "react";
 import type { VisualizationSpec } from "vega-embed";
@@ -199,14 +200,21 @@ const EvictionVizWithValues: React.FC<EvictionVizProps & {
   return <LazyVegaLite spec={spec} className={VIZ_TIME_SERIES_CLASS} />;
 };
 
+const EVICTION_VISUALIZATIONS: Map<keyof EvictionTimeSeriesNumericFields, string> = new Map([
+  ["total_filings", "Total NY State Eviction Filings"],
+  ["nyc_holdover_filings", "NYC Holdover Filings"],
+  ["nyc_nonpay_filings", "NYC Non-Payment Filings"],
+  ["outside_nyc_holdover_filings", "Upstate Holdover Filings"],
+  ["outside_nyc_nonpay_filings", "Upstate Non-Payment Filings"],
+]);
+
 export const EvictionVisualizations: React.FC<{
   height: number,
-}> = ({height}) => {
+  fieldNames?: (keyof EvictionTimeSeriesNumericFields)[]
+}> = ({height, fieldNames}) => {
   const [timeUnit, setTimeUnit] = useState<EvictionTimeUnit>("yearweek");
-  const props: Pick<EvictionVizProps, 'timeUnit'|'height'> = {
-    height,
-    timeUnit,
-  };
+
+  fieldNames = fieldNames || Array.from(EVICTION_VISUALIZATIONS.keys());
 
   return (
     <>
@@ -225,11 +233,15 @@ export const EvictionVisualizations: React.FC<{
           Month
         </label>
       </p>
-      <EvictionViz {...props} fieldName="total_filings" title="Total NY State Eviction Filings" />
-      <EvictionViz {...props} fieldName="nyc_holdover_filings" title="NYC Holdover Filings" />
-      <EvictionViz {...props} fieldName="nyc_nonpay_filings" title="NYC Non-Payment Filings" />
-      <EvictionViz {...props} fieldName="outside_nyc_holdover_filings" title="Upstate Holdover Filings" />
-      <EvictionViz {...props} fieldName="outside_nyc_nonpay_filings" title="Upstate Non-Payment Filings" />
+      {fieldNames.map(fieldName => (
+        <EvictionViz
+          key={fieldName}
+          height={height}
+          timeUnit={timeUnit}
+          fieldName={fieldName}
+          title={assertNotUndefined(EVICTION_VISUALIZATIONS.get(fieldName))}
+        />
+      ))}
     </>
   );
 };


### PR DESCRIPTION
This adds a new link at the bottom of the page called "Configure this page as a widget".  If followed, a form will appear that allows the user to receive a URL that embeds any time series plot of their choice.