### PR TITLE
Add timezone specification to deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,9 @@ jobs:
           persist-credentials: false
 
       - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
+        uses: zcong1993/setup-timezone@master # Adapted from: https://github.com/marketplace/actions/setup-timezone
+        with:
+          timezone: America/New_York
         env:
           NYCDB_URL: ${{ secrets.NYCDB_URL }}
         run: |


### PR DESCRIPTION
This PR attempts to find a solution for #27 by specifying the New York timezone in our deploy github workflow function.