### PR TITLE
Sort Map data by residential units only

### DIFF
--- a/lib/filings-by-zip/data.ts
+++ b/lib/filings-by-zip/data.ts
@@ -7,8 +7,7 @@ export const FILINGS_BY_ZIP_EMPTY_ROW: FilingsByZipRow = {
   zipcode: '',
   filings_since_032320: 0,
   unitsres_total: null,
-  unitsres_2: null,
-  filingsrate_total: null,
+  unitsrental: null,
   filingsrate_2plus: null,
 };
 
@@ -17,8 +16,7 @@ export function convertFilingsByZipRow(row: any) {
     zipcode: ensureString(row.zipcode),
     filings_since_032320: toInt(row.filings_since_032320),
     unitsres_total: toIntOrNull(row.unitsres_total),
-    unitsres_2: toIntOrNull(row.unitsres_2),
-    filingsrate_total: toIntOrNull(row.filingsrate_total),
+    unitsrental: toIntOrNull(row.unitsrental),
     filingsrate_2plus: toIntOrNull(row.filingsrate_2plus),
   };
 }
@@ -30,8 +28,7 @@ function getCsvHeader(): string[] {
     'zipcode',
     'filings_since_032320',
     'unitsres_total',
-    'unitsres_2',
-    'filingsrate_total',
+    'unitsrental',
     'filingsrate_2plus',
   ];
 }
@@ -41,8 +38,7 @@ function toCsvRow(row: FilingsByZipRow): string[] {
     row.zipcode,
     row.filings_since_032320.toString(),
     row.unitsres_total?.toString() ?? '',
-    row.unitsres_2?.toString() ?? '',
-    row.filingsrate_total?.toString() ?? '',
+    row.unitsrental?.toString() ?? '',
     row.filingsrate_2plus?.toString() ?? '',
   ];
 }

--- a/lib/filings-by-zip/viz.tsx
+++ b/lib/filings-by-zip/viz.tsx
@@ -49,7 +49,7 @@ const ZipCodeVizWithValues: React.FC<{
     width: "container",
     height,
     title: {
-      text: `NYC Eviction Filings By Zip Code, March 23, 2020 - Present`,
+      text: `NYC Residential Eviction Filings By Zip Code, March 23, 2020 - Present`,
     },
     data: {
       values: geoJson.features,
@@ -66,6 +66,7 @@ const ZipCodeVizWithValues: React.FC<{
           "Filings per unit of multi-family",
           "buildings"
         ],
+        scale: {"scheme": "reds"}
       },
       tooltip: [
         {

--- a/sql/eviction-time-series.sql
+++ b/sql/eviction-time-series.sql
@@ -27,6 +27,7 @@ select
 			else 'Outside NYC' end as region
 		from oca_index i 
 		where i.fileddate >= '01-01-2019' and i.classification = any('{Holdover,Non-Payment}') 
+		and propertytype = 'Residential'
 		order by i.fileddate asc 
 	) eviction_cases using(day)
 group by day

--- a/sql/eviction-time-series.sql
+++ b/sql/eviction-time-series.sql
@@ -27,7 +27,6 @@ select
 			else 'Outside NYC' end as region
 		from oca_index i 
 		where i.fileddate >= '01-01-2019' and i.classification = any('{Holdover,Non-Payment}') 
-		and propertytype = 'Residential'
 		order by i.fileddate asc 
 	) eviction_cases using(day)
 group by day

--- a/sql/filings-by-zip-since-0323.sql
+++ b/sql/filings-by-zip-since-0323.sql
@@ -1,6 +1,3 @@
--- Updated 12/8/20 to join with residential units by zip code (except for 1-unit properties)
--- Total numbers of filings per zip are lower than previous method, unclear why.
-
 with 
 filings_zips as (
 	select 
@@ -9,7 +6,9 @@ filings_zips as (
 	from oca_index i 
 	left join oca_causes c on c.indexnumberid = i.indexnumberid
 	left join oca_addresses a on a.indexnumberid = i.indexnumberid
-	where i.fileddate >= '03-23-2020' and i.classification = any('{Holdover,Non-Payment}') and
+	where i.fileddate >= '03-23-2020' and i.classification = any('{Holdover,Non-Payment}') 
+	and propertytype = 'Residential'
+	and
 	(court = 'New York County Civil Court' or 
 		court = 'Kings County Civil Court' or 
 		court = 'Queens County Civil Court' or 
@@ -30,7 +29,7 @@ order by zipcode),
 grouped_unitsres as (
 select zipcode, 
 sum(unitsres) as unitsres_total,
-sum(unitsres) filter (where unitstotal > 1) as unitsres_2
+sum(unitsres) filter (where unitstotal > 1) as unitsrental
 from pluto_19v2
 group by zipcode
 order by zipcode)
@@ -38,13 +37,14 @@ order by zipcode)
 select a.zipcode, 
 -- total filings since 03/23/2020
 filings_since_032320, 
--- total residential units in the zip code as per PLUTO
+--total residential units in the zip code as per PLUTO
 unitsres_total, 
--- total residential units in the zip code except for single unit properties
-unitsres_2,
--- filings normalized by total res units in the zip code
-filings_since_032320 * 1000 / nullif(unitsres_total, 0)::numeric as filingsrate_total, 
--- filings normalized by total res units in the zip code except for single unit properties. 
-filings_since_032320 * 1000 / nullif(unitsres_2, 0)::numeric as filingsrate_2plus
+--total residential units in the zip code except for single unit properties
+unitsrental,
+--filings normalized by total res units in the zip code except for single unit properties. 
+filings_since_032320 * 1000 / nullif(unitsrental, 0)::numeric as filingsrate_2plus
 from grouped_zips a
 left join grouped_unitsres b on b.zipcode = a.zipcode 
+
+/*For map of filings by zip code, make choropleth using filingsrate_2plus
+include filings_since_032320 in tool tip*/


### PR DESCRIPTION
This PR incorporates @lblok's changes from #29 by editing our SQL code to filter the map's data by residential units.  