### PR TITLE
Make map, total active cases embeddable.

### DIFF
--- a/lib/total-active-cases/viz.tsx
+++ b/lib/total-active-cases/viz.tsx
@@ -282,24 +282,6 @@ export const ActiveCasesVisualizations: React.FC<{
 
   return (
     <>
-      {/* <p>
-        View by:&nbsp;&nbsp;
-        <label>
-          <input type="radio" name="timeUnit" value="yearmonthdate" checked={timeUnit === "yearmonthdate"} onChange={(e) => setTimeUnit("yearmonthdate")} />
-          Day
-        </label>&nbsp;&nbsp;
-        <label>
-          <input type="radio" name="timeUnit" value="yearweek" checked={timeUnit === "yearweek"} onChange={(e) => setTimeUnit("yearweek")} />
-          Week
-        </label>&nbsp;&nbsp;
-        <label>
-          <input type="radio" name="timeUnit" value="yearmonth" checked={timeUnit === "yearmonth"} onChange={(e) => setTimeUnit("yearmonth")} />
-          Month
-        </label>
-      </p> 
-      Commented out because not working properly and probably not necessary for total active cases.
-      */}
-      
       {fieldNames.map(fieldName => (
         <ActiveCasesViz
           key={fieldName}


### PR DESCRIPTION
This makes the other two visualizations embeddable via an "other visualizations" section in the widget configurator page:

> ![image](https://user-images.githubusercontent.com/124687/105754909-9cd52400-5f18-11eb-96ac-2d951d0c7a35.png)
