### PR TITLE
Reorder graphs, match pandemic start days, add clarification

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,10 @@
 
       .viz-time-series {
         width: 100%;
+        height: 500px;
+      }
+
+      .viz-time-series-short {
         height: 300px;
       }
 

--- a/index.tsx
+++ b/index.tsx
@@ -12,9 +12,7 @@ import { VizFallback, VIZ_GEO_CLASS } from "./lib/viz-util";
 
 const EVICTION_VIZ_DEFAULT_HEIGHT = 150;
 
-const ACTIVE_CASES_VIZ_DEFAULT_HEIGHT = 150;
-
-const ACTIVE_CASES_TABLE_DEFAULT_HEIGHT = 150;
+const ACTIVE_CASES_VIZ_DEFAULT_HEIGHT = 500;
 
 const VIEW_WIDGET = "widget";
 
@@ -58,7 +56,7 @@ const FullDocument: React.FC<{}> = () => (
     <br/>
     <h2>Active Cases in 2020</h2>
     <ActiveCasesVisualizations height={ACTIVE_CASES_VIZ_DEFAULT_HEIGHT} />
-    <br />
+    <br/>
     <h2>Filings by zip code</h2>
     <LazyZipCodeViz height={600} />
     <small><strong>Data sources:</strong> New York State Office of Court Administration eviction filings and PLUTO19v2 via <a href="https://github.com/nycdb/nycdb" target="_blank">NYCDB</a>. By the <a href="https://housingdatanyc.org" target="_blank">Housing Data Coalition</a>, <a href="https://justfix.nyc" target="_blank">JustFix.nyc</a>, and <a href="https://anhd.org" target="_blank">ANHD</a>. *Numbers of total units per zip code exclude single-unit properties to approximate the number of rental units.</small>

--- a/index.tsx
+++ b/index.tsx
@@ -56,6 +56,9 @@ const FullDocument: React.FC<{}> = () => (
     <h2>Total Active Cases</h2>
     <ActiveCasesTable />
     <br/>
+    <h2>Active Cases in 2020</h2>
+    <ActiveCasesVisualizations height={ACTIVE_CASES_VIZ_DEFAULT_HEIGHT} />
+    <br />
     <h2>Filings by zip code</h2>
     <LazyZipCodeViz height={600} />
     <small><strong>Data sources:</strong> New York State Office of Court Administration eviction filings and PLUTO19v2 via <a href="https://github.com/nycdb/nycdb" target="_blank">NYCDB</a>. By the <a href="https://housingdatanyc.org" target="_blank">Housing Data Coalition</a>, <a href="https://justfix.nyc" target="_blank">JustFix.nyc</a>, and <a href="https://anhd.org" target="_blank">ANHD</a>. *Numbers of total units per zip code exclude single-unit properties to approximate the number of rental units.</small>
@@ -67,8 +70,6 @@ const FullDocument: React.FC<{}> = () => (
     <p><a href={`?${QS_VIEW}=${VIEW_CONFIGURE_WIDGET}`}>Configure this page as a widget</a></p>
     <p><a href="https://github.com/housing-data-coalition/rtc-eviction-viz">Learn more on GitHub</a></p>
     <br/>
-    <h2>Active Cases in 2020</h2>
-    <ActiveCasesVisualizations height={ACTIVE_CASES_VIZ_DEFAULT_HEIGHT} />
   </div>
 );
 

--- a/lib/eviction-time-series/viz.tsx
+++ b/lib/eviction-time-series/viz.tsx
@@ -72,7 +72,7 @@ const EvictionVizWithValues: React.FC<EvictionVizProps & {
     title: {
       text: `${title}, 2020 - Present`,
       subtitle: [
-        `Cases since COVID-19: ${casesSinceCovid.toLocaleString()}`,
+        `Cases since COVID-19 (all cases, active and disposed): ${casesSinceCovid.toLocaleString()}`,
         // This effectively adds extra padding below the subtitle.
         ""
       ]

--- a/lib/eviction-time-series/viz.tsx
+++ b/lib/eviction-time-series/viz.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import type { VisualizationSpec } from "vega-embed";
 import { JsonLoader } from "../json-loader";
 import { LazyVegaLite } from "../vega-lazy";
-import { VizFallback, VIZ_TIME_SERIES_CLASS } from "../viz-util";
+import { VizFallback, VIZ_TIME_SERIES_CLASS, VIZ_TIME_SERIES_SHORT_CLASS } from "../viz-util";
 import { EvictionTimeSeriesNumericFields, EvictionTimeSeriesRow, EVICTION_TIME_SERIES } from "./data";
 
 /**
@@ -39,8 +39,10 @@ type EvictionVizProps = {
 
 const EvictionViz: React.FC<EvictionVizProps> = (props) => {
   return (
-    <JsonLoader<EvictionTimeSeriesRow[]> url={EVICTION_TIME_SERIES.json} fallback={<VizFallback className={VIZ_TIME_SERIES_CLASS} />}>
-      {(values) => <EvictionVizWithValues values={values} {...props} />}
+    <JsonLoader<EvictionTimeSeriesRow[]>
+      url={EVICTION_TIME_SERIES.json}
+      fallback={<VizFallback className={`${VIZ_TIME_SERIES_CLASS} ${VIZ_TIME_SERIES_SHORT_CLASS}`} />}>
+        {(values) => <EvictionVizWithValues values={values} {...props} />}
     </JsonLoader>
   );
 };
@@ -197,7 +199,7 @@ const EvictionVizWithValues: React.FC<EvictionVizProps & {
     ],
   };
 
-  return <LazyVegaLite spec={spec} className={VIZ_TIME_SERIES_CLASS} />;
+  return <LazyVegaLite spec={spec} className={`${VIZ_TIME_SERIES_SHORT_CLASS} ${VIZ_TIME_SERIES_CLASS}`}/>;
 };
 
 export function isEvictionTimeSeriesNumericField(value: string): value is keyof EvictionTimeSeriesNumericFields {

--- a/lib/viz-util.tsx
+++ b/lib/viz-util.tsx
@@ -5,6 +5,7 @@ export const VIZ_GEO_CLASS = "viz-geo";
 
 /** A visualization that represents a time series. */
 export const VIZ_TIME_SERIES_CLASS = "viz-time-series";
+export const VIZ_TIME_SERIES_SHORT_CLASS = "viz-time-series-short";
 
 /** A visualization that represents a table. */
 export const VIZ_TABLE_CLASS = "viz-table";

--- a/sql/total-active-cases-table.sql
+++ b/sql/total-active-cases-table.sql
@@ -15,7 +15,7 @@ with t as (
         }')) then 'NYC' 
         else 'Outside NYC' end as region,
         case when
-            fileddate < '2020-03-21' then 'Issued Prepandemic'
+            fileddate < '2020-03-23' then 'Issued Prepandemic'
             else 'Issued Pandemic' end as timebucket
     from oca_index
     where status ~ 'Active' and


### PR DESCRIPTION
This accomplishes 3 things to make the RTC eviction tracker closer to the desired redesign.

1. Reorders the "Active Cases in 2020-2021" graph to be after the table.
2. Previously the graphs and the table were 2 days off on the definition of the beginning of the pandemic; fixes that.
3. Clarifies that the `Filings Over Time` graphs include both active and disposed cases, and hence have different numbers from the table (which only has active).
4. Fixes an issue where the size of the `Active Cases in 2020-2021` graph was not registering as the correct height and so was overlapping another graph when it was moved up from the bottom.

[ch7262] [ch7261]