### PR TITLE
Help users see the last time the site was deployed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,12 +23,6 @@ jobs:
         with:
           timezone: America/New_York
 
-      - name: Set Current Date in Env 📅
-        run: echo $(date) >> $LAST_DEPLOY_DATE
-
-      - name: Test Setting Current Date in Env 🧪
-        run: $LAST_DEPLOY_DATE
-
       - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
         env:
           NYCDB_URL: ${{ secrets.NYCDB_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,12 @@ jobs:
         with:
           timezone: America/New_York
 
+      - name: Set Current Date in Env 📅
+        run: echo $(date) >> $LAST_DEPLOY_DATE
+
+      - name: Test Setting Current Date in Env 🧪
+        run: $LAST_DEPLOY_DATE
+
       - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
         env:
           NYCDB_URL: ${{ secrets.NYCDB_URL }}

--- a/index.tsx
+++ b/index.tsx
@@ -96,6 +96,7 @@ const FullDocument: React.FC<{}> = () => (
     <DatasetDownloads files={EVICTION_TIME_SERIES} title="filings over time" />
     <p><a href={`?${QS_VIEW}=${VIEW_CONFIGURE_WIDGET}`}>Configure this page as a widget</a></p>
     <p><a href="https://github.com/housing-data-coalition/rtc-eviction-viz">Learn more on GitHub</a></p>
+    <p><a href="https://github.com/housing-data-coalition/rtc-eviction-viz/actions/workflows/deploy.yml">See when this site was last deployed</a></p>
     <br/>
   </div>
 );


### PR DESCRIPTION
This PR adds a link to the [Github Actions deploy logs](https://github.com/housing-data-coalition/rtc-eviction-viz/actions/workflows/deploy.yml) in the list of helpful links found in the footer of the site.