### PR TITLE
Add noindex tag to HTML head to block search engine results

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex">
     <title>NY Eviction Filings Tracker</title>
     <style>
       html,


### PR DESCRIPTION
We got a request from RTC to limit search hits for the site, given that it's in development and intended for RTC internal use.