### PR TITLE
Add basename to main router

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ yarn build-data
 yarn watch
 ```
 
-Then visit http://localhost:1234.
+Then visit http://localhost:1234/rtc-eviction-viz.
 
 ## Updating data
 
@@ -28,6 +28,6 @@ To deploy the site, run `yarn deploy`.
 
 ## Manual Tests
 
-- Make sure both [/](http://localhost:1234) and [/?view=widget](http://localhost:1234?view=widget&fieldName=total_active_cases&height=150) routes work.
-- [/](http://localhost:1234) should only require a login once.
-- [view=widget](http://localhost:1234?view=widget&fieldName=total_active_cases&height=150) should not require any auth.
+- Make sure both [/rtc-eviction-viz](http://localhost:1234/rtc-eviction-viz) and [/rtc-eviction-viz/?view=widget](http://localhost:1234/rtc-eviction-viz?view=widget&fieldName=total_active_cases&height=150) routes work.
+- [/rtc-eviction-viz](http://localhost:1234/rtc-eviction-viz) should only require a login once.
+- [view=widget](http://localhost:1234/rtc-eviction-viz?view=widget&fieldName=total_active_cases&height=150) should not require any auth.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ To deploy the site, run `yarn deploy`.
 
 ## Manual Tests
 
-- Make sure both [/rtc-eviction-viz](http://localhost:1234/rtc-eviction-viz) and [/rtc-eviction-viz/?view=widget](http://localhost:1234/rtc-eviction-viz?view=widget&fieldName=total_active_cases&height=150) routes work.
+- Make sure both [/rtc-eviction-viz](http://localhost:1234/rtc-eviction-viz) and [/rtc-eviction-viz?view=widget](http://localhost:1234/rtc-eviction-viz?view=widget&fieldName=total_active_cases&height=150) routes work.
 - [/rtc-eviction-viz](http://localhost:1234/rtc-eviction-viz) should only require a login once.
 - [view=widget](http://localhost:1234/rtc-eviction-viz?view=widget&fieldName=total_active_cases&height=150) should not require any auth.

--- a/main.tsx
+++ b/main.tsx
@@ -9,7 +9,7 @@ import {
   useLocation,
 } from "react-router-dom";
 import { getHTMLElement } from "@justfixnyc/util";
-import {AuthContext, AuthProvider} from "./auth"
+import { AuthContext, AuthProvider } from "./auth"
 import {
   Widget,
   FullDocument,
@@ -112,7 +112,7 @@ const App: React.FC<{}> = () => {
 
 async function main() {
   ReactDOM.render(
-    <BrowserRouter>
+    <BrowserRouter basename="rtc-eviction-viz">
       <App />
     </BrowserRouter>,
     getHTMLElement("div", "#app")


### PR DESCRIPTION
Since our GH pages set up uses the basename `rtc-eviction-viz`, this PR is an attempt to achieve dev prod parity in setting this basename explicitly within the <Router> component on main.tsx. 