### PR TITLE
optimize slow share-rep query breaking builds

### DIFF
--- a/sql/share-represented.sql
+++ b/sql/share-represented.sql
@@ -1,43 +1,48 @@
--- select appearances where at least two have occurred at least one week ago, because tenants should have attorneys after two appearances. methodology updated 12/21/22
-with appears_twice as (
-	select indexnumberid, count(distinct(indexnumberid,appearancedatetime)) from oca_appearances
-	where appearancedatetime < current_date - interval '1 weeks'
-	group by indexnumberid 
-	having count(distinct(indexnumberid,appearancedatetime)) > 1 -- updated 12/22 to account for duplicate first appearancesd
-),
--- select non-payment and holdover cases' respondents and representation types, filed after the eviction moratorium expired, that have had their first appearance within the last week
-cases_plus_rep as (
-	select 
-		oi.*,
-		representationtype 
-	from oca_index oi  
-	left join oca_parties op using(indexnumberid)
-	inner join appears_twice using(indexnumberid)
-	where oi.classification in ('Non-Payment','Holdover')
-		and role = 'Respondent' 
-		and propertytype = 'Residential'
-		and representationtype != 'No Appearance' -- filter out no appearances 
-		and oi.court = any('{
-						Bronx County Civil Court,
-						Kings County Civil Court,
-						New York County Civil Court,
-						Queens County Civil Court,
-						Richmond County Civil Court,
-						Redhook Community Justice Center,
-						Harlem Community Justice Center
-					}')
-		-- grab everything after the eviction moratorium ended
-		and fileddate > '2022-01-15'
-		),
--- select just relevant fields and eliminate duplicates
-all_cases as (
+
+create temp table x_all_cases as (
+
+	-- select appearances where at least two have occurred at least one week ago, because tenants should have attorneys after two appearances. methodology updated 12/21/22
+	with appears_twice as (
+		select indexnumberid, count(distinct(indexnumberid,appearancedatetime)) from oca_appearances
+		where appearancedatetime < current_date - interval '1 weeks'
+		group by indexnumberid 
+		having count(distinct(indexnumberid,appearancedatetime)) > 1 -- updated 12/22 to account for duplicate first appearancesd
+	), 
+	-- select non-payment and holdover cases' respondents and representation types, filed after the eviction moratorium expired, that have had their first appearance within the last week
+	cases_plus_rep as (
+		select 
+			oi.*,
+			representationtype 
+		from oca_index oi  
+		left join oca_parties op using(indexnumberid)
+		inner join appears_twice using(indexnumberid)
+		where oi.classification in ('Non-Payment','Holdover')
+			and role = 'Respondent' 
+			and propertytype = 'Residential'
+			and representationtype != 'No Appearance' -- filter out no appearances 
+			and oi.court = any('{
+							Bronx County Civil Court,
+							Kings County Civil Court,
+							New York County Civil Court,
+							Queens County Civil Court,
+							Richmond County Civil Court,
+							Redhook Community Justice Center,
+							Harlem Community Justice Center
+						}')
+			-- grab everything after the eviction moratorium ended
+			and fileddate > '2022-01-15'
+	)
+	-- select just relevant fields and eliminate duplicates
 	select 
 		indexnumberid, 
 		date_trunc('week', fileddate)::date as day, 
 		string_agg(distinct representationtype, ', ') as representationtype
 	from cases_plus_rep
 	group by indexnumberid, day
-)
+);
+
+create index on x_all_cases (indexnumberid, day);
+
 -- group by week filed and calculated representation rate 
 select 
    	day,
@@ -49,9 +54,9 @@ select
 	count(*) as allcases,
 	-- Calculate percent of cases that had representation
 	round((count(*) filter (where representationtype != 'SRL'))::numeric*100 / count(*), 1) as rep_rate
-from all_cases
+from x_all_cases
 -- grab everything after the eviction moratorium ended
 where day < current_date - interval '4 weeks'
 group by day 
 having count(*) > 100 -- only include weeks with over 100 total cases 
-order by day
+order by day;


### PR DESCRIPTION
We recently noticed that the build has been failing on-and-off since we added the share-represented query. It seems like it just takes much longer than others and so the connection would sometimes get interrupted and break everything. There might be some more we could do to prevent the connection issue, or handle errors and retry failed queries. But for now, I've just made an attempt to speed up that query. I did [`explain analyze`](https://thoughtbot.com/blog/reading-an-explain-analyze-query-plan) and as expected the part taking all the time was the last aggregation by un-indexed column (`day`). So I split up the query and instead of all one CTE, I made a temporary table with the `all_cases` so we can add an index on those grouping column before the final aggregation query. This seems to speed it up a lot. Hopefully this does the trick!