### PR TITLE
add workflow for deploy previews for PRs

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,40 @@
+name: Build and Deploy PR Preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        with:
+          persist-credentials: false
+
+      - name: Set Timezone 🕑
+        uses: zcong1993/setup-timezone@master # Adapted from: https://github.com/marketplace/actions/setup-timezone
+        with:
+          timezone: America/New_York
+
+      - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
+        env:
+          NYCDB_URL: ${{ secrets.NYCDB_URL }}
+          REACT_APP_PASSWORD: ${{ secrets.REACT_APP_PASSWORD }}
+        run: |
+          yarn install
+          yarn build-data
+          yarn build
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./dist/
+          preview-branch: gh-pages

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -38,3 +38,4 @@ jobs:
         with:
           source-dir: ./dist/
           preview-branch: gh-pages
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds a new GitHub Actions workflow to deploy a preview version of the website for each pull request. This will help us ensure that any changes look right on the final deployed site, since there have been some issues with parity between local testing and the main production site. (#78 )