### PR TITLE
exclude null zipcode records in filings

### DIFF
--- a/sql/filings-by-zip-since-0323.sql
+++ b/sql/filings-by-zip-since-0323.sql
@@ -17,23 +17,27 @@ filings_zips as (
 		court = 'Harlem Community Justice Center')
 	order by i.fileddate asc),
 
-grouped_zips as (
-select
-zipcode,
-count(*) as filings_since_032320
-from filings_zips
-group by zipcode
-order by zipcode),
+	grouped_zips as (
+		select
+			zipcode,
+			count(*) as filings_since_032320
+		from filings_zips
+		group by zipcode
+		order by zipcode
+	),
 
-grouped_unitsres as (
-select zipcode, 
-sum(unitsres) as unitsres_total,
-sum(unitsres) filter (where unitstotal > 1) as unitsrental
-from pluto_19v2
-group by zipcode
-order by zipcode)
+	grouped_unitsres as (
+		select 
+			zipcode, 
+			sum(unitsres) as unitsres_total,
+			sum(unitsres) filter (where unitstotal > 1) as unitsrental
+		from pluto_19v2
+		group by zipcode
+		order by zipcode
+	)
 
-select a.zipcode, 
+select 
+zipcode, 
 -- total filings since 03/23/2020
 filings_since_032320, 
 --total residential units in the zip code as per PLUTO
@@ -43,7 +47,8 @@ unitsrental,
 --filings normalized by total res units in the zip code except for single unit properties. 
 filings_since_032320 * 1000 / nullif(unitsrental, 0)::numeric as filingsrate_2plus
 from grouped_zips a
-left join grouped_unitsres b on b.zipcode = a.zipcode 
+left join grouped_unitsres b using(zipcode)
+where zipcode is not null
 
 /*For map of filings by zip code, make choropleth using filingsrate_2plus
 include filings_since_032320 in tool tip*/

--- a/sql/filings-by-zip-table-outside-nyc.sql
+++ b/sql/filings-by-zip-table-outside-nyc.sql
@@ -15,12 +15,14 @@ filings_zips as (
 	'Richmond County Civil Court',
 	'Redhook Community Justice Center',
 	'Harlem Community Justice Center')
-	order by i.fileddate asc)
+	order by i.fileddate asc
+)
 
 select
-zipcode,
-count(*) as filings,
-court_name
+	zipcode,
+	count(*) as filings,
+	court_name
 from filings_zips
+where zipcode is not null
 group by court_name, zipcode
 order by court_name


### PR DESCRIPTION
the build was failing because there are some records with `NULL` values for zipcode, and the validation before building the charts expects string values. I've excluded these null zip values