### PR TITLE
increase statement_timeout for share rep query

### DIFF
--- a/sql/share-represented.sql
+++ b/sql/share-represented.sql
@@ -1,4 +1,6 @@
 
+set statement_timeout = '5min';
+
 create temp table x_all_cases as (
 
 	-- select appearances where at least two have occurred at least one week ago, because tenants should have attorneys after two appearances. methodology updated 12/21/22


### PR DESCRIPTION
We recently added a 1min `statement_timeout` for the `anon` user role that we're connecting with here, but the query for share represented takes a bit longer and so we increase the timeout just for the session before running that query.